### PR TITLE
Fixes npm install failure on linux due to fsevents

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2326,6 +2326,7 @@
       "version": "1.0.14",
       "from": "fsevents@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
+      "optional": true,
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",


### PR DESCRIPTION
Manually edited npm-shrinkwrap.json to make fsevents optional.  This works for now, but the proper fix is to regenerate the file on an osx machine with a new version of npm (e.g. v3.10.10).  (Prune first, though!  See https://github.com/ngokli/react-redux-boilerplate/commit/296e8a3f3db22e61be3bc218187c68382052c24e )